### PR TITLE
Allow for decimal multipliers.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -211,7 +211,7 @@ class SettingsTab extends PluginSettingTab {
         speedSlider = slider
         slider
           .setValue(this.plugin.settings.speed)
-          .setLimits(1, 10, 1)
+          .setLimits(0.1, 10, 0.1)
           .setDynamicTooltip()
           .onChange(async value => {
             this.plugin.settings.speed = value
@@ -237,7 +237,7 @@ class SettingsTab extends PluginSettingTab {
         altMultiplierSlider = slider
         slider
           .setValue(this.plugin.settings.altMultiplier)
-          .setLimits(1, 10, 1)
+          .setLimits(0.1, 10, 0.1)
           .setDynamicTooltip()
           .onChange(async value => {
             this.plugin.settings.altMultiplier = value


### PR DESCRIPTION
Changes the minimum value of sliders to `0.1` and their step to `0.1` for decimal multipliers. This change was really simple so apologies in advance if whole numbers were chosen deliberately.

I had installed this plugin with the hope of reducing my scroll speed rather than increasing it, which I achieved by editing the `data.json` file directly. Since decimal value worked there I figured I would edit the plugin to have the settings interface to support it better.

Thanks for the really well made plugin :D